### PR TITLE
Rename install param 'install-path' to 'path'

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -5,7 +5,7 @@ parameters:
     type: string
     default: "latest"
     description: "Version of the SecretHub CLI"
-  install-path:
+  path:
     type: string
     default: /usr/local/bin
     description: "Path to install SecretHub CLI to"
@@ -44,13 +44,13 @@ steps:
           curl -sSfL https://github.com/secrethub/secrethub-cli/releases/download/v$VERSION/secrethub-v$VERSION-$PLATFORM-amd64.tar.gz | tar zxf - -C ./secrethub
 
           # check if we can install the CLI without sudo
-          if ! mv ./secrethub/bin/secrethub << parameters.install-path >> 2>/dev/null ; then
-            sudo mv ./secrethub/bin/secrethub << parameters.install-path >>
+          if ! mv ./secrethub/bin/secrethub << parameters.path >> 2>/dev/null ; then
+            sudo mv ./secrethub/bin/secrethub << parameters.path >>
           fi
           rm -rf ./secrethub
 
           # Add executable to path if it is not there already.
-          if ! echo ":$PATH:" | grep -q  ":<<parameters.install-path>>:"; then
-            echo 'export PATH="$PATH:<<parameters.install-path>>"' >> $BASH_ENV;
+          if ! echo ":$PATH:" | grep -q  ":<<parameters.path>>:"; then
+            echo 'export PATH="$PATH:<<parameters.path>>"' >> $BASH_ENV;
           fi
         fi


### PR DESCRIPTION
Just esthetics. The command is already called `install`.
```yml
- secrethub/install:
     path: /usr/local/bin
```
