### PR TITLE
Add integration tests and publishing to orb registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - checkout
       - secrethub/exec:
+          step-name: Validate if secrets have been provisioned
           command: |
             set -e
             : ${DOCKER_USERNAME:?DOCKER_USERNAME is not set}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,16 +19,16 @@ jobs:
     docker:
       - image: cimg/base:stable
     environment:
-      DOCKER_USERNAME: secrethub://company/app/docker/username
-      DOCKER_PASSWORD: secrethub://company/app/docker/password
+      SECRET: secrethub://company/app/secret
     steps:
       - checkout
       - secrethub/exec:
-          step-name: Validate if secrets have been provisioned
+          step-name: Validate if secret is set correctly
           command: |
-            set -e
-            : ${DOCKER_USERNAME:?DOCKER_USERNAME is not set}
-            : ${DOCKER_PASSWORD:?DOCKER_PASSWORD is not set}
+            if [ $SECRET != "DDXLKkBhprQgW7w7OFsM8y" ]; then
+              echo "secret is not correctly set"
+              exit 1
+            fi
   test-integration-other-orb:
     executor: aws-cli/default
     shell: secrethub run -- /bin/bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,47 @@ version: 2.1
 
 orbs:
   orb-tools: circleci/orb-tools@9.0.0
+  # Integration tests
+  secrethub: secrethub/cli@<<pipeline.parameters.dev-orb-version>>
+  aws-cli: circleci/aws-cli@0.1.22
+
+parameters:
+  run-integration-tests:
+    type: boolean
+    default: false
+  dev-orb-version:
+    type: string
+    default: "dev:latest"
+
+jobs:
+  test-integration-exec:
+    docker:
+      - image: cimg/base:stable
+    environment:
+      DOCKER_USERNAME: secrethub://company/app/docker/username
+      DOCKER_PASSWORD: secrethub://company/app/docker/password
+    steps:
+      - checkout
+      - secrethub/exec:
+          command: |
+            set -e
+            : ${DOCKER_USERNAME:?DOCKER_USERNAME is not set}
+            : ${DOCKER_PASSWORD:?DOCKER_PASSWORD is not set}
+  test-integration-other-orb:
+    executor: aws-cli/default
+    shell: secrethub run -- /bin/bash
+    environment:
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: secrethub://company/app/aws/access_key_id
+      AWS_SECRET_ACCESS_KEY: secrethub://company/app/aws/secret_access_key
+    steps:
+      - secrethub/install
+      - checkout
+      - aws-cli/setup
 
 workflows:
   validate_publish-dev:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       - orb-tools/lint
       - orb-tools/pack
@@ -29,3 +67,14 @@ workflows:
           filters:
             branches:
               only: master
+      - orb-tools/trigger-integration-tests-workflow:
+          name: trigger-integration-tests
+          context: publish-orb-dev
+          requires:
+            - publish-dev-sha
+
+  test-integration_publish-to-registry:
+    when: << pipeline.parameters.run-integration-tests >>
+    jobs:
+      - test-integration-exec
+      - test-integration-other-orb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,9 +84,9 @@ workflows:
           orb-name: secrethub/cli
           context: publish-orb-prd
           add-pr-comment: false
-          major-release-tag-regex: '^major-v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
-          minor-release-tag-regex: '^minor-v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
-          patch-release-tag-regex: '^patch-v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
+          major-release-tag-regex: '^v[1-9][0-9]*\.0\.0+$'
+          minor-release-tag-regex: '^v[0-9]*\.[1-9][0-9]*\.0+$'
+          patch-release-tag-regex: '^v[0-9]*\.[0-9]*\.[1-9][0-9]*$'
           requires:
             - test-integration-exec
             - test-integration-other-orb
@@ -94,4 +94,4 @@ workflows:
             branches:
               only: master
             tags:
-              only: /^(major|minor|patch)-v\d+\.\d+\.\d+$/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,3 +79,19 @@ workflows:
     jobs:
       - test-integration-exec
       - test-integration-other-orb
+      - orb-tools/dev-promote-prod-from-git-tag:
+          name: publish-to-registry
+          orb-name: secrethub/cli
+          context: publish-orb-prd
+          add-pr-comment: false
+          major-release-tag-regex: '^major-v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
+          minor-release-tag-regex: '^minor-v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
+          patch-release-tag-regex: '^patch-v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
+          requires:
+            - test-integration-exec
+            - test-integration-other-orb
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^(major|minor|patch)-v\d+\.\d+\.\d+$/


### PR DESCRIPTION
Idea is: first publish dev orb, then trigger a second pipeline which imports the newly published dev orb and uses it to run tests. And if that succeeds on a tag, publish it to the registry.

~One thing to note: the CircleCI CLI (and therefore `orb-tools` orb too) requires explicitly setting whether the release is `major`, `minor`, or `patch`. So we'll have to include that in the tag name unfortunately: e.g. `minor-v0.1.0`.~