### PR TITLE
Remove orphaned closing anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <p align="center">
   <img src="https://secrethub.io/img/integrations/circleci/github-banner.png?v1" alt="CircleCI + SecretHub" width="390">
-  </a>
 </p>
 <br/>
 


### PR DESCRIPTION
The opening tag has been removed, but the closing tag was still there.