### PR TITLE
Improve CLI install step name

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -16,7 +16,7 @@ parameters:
 
 steps:
   - run:
-      name: "Install SecretHub CLI"
+      name: "Ensure SecretHub CLI is installed"
       shell: << parameters.shell >>
       environment:
         SECRETHUB_CLI_VERSION: << parameters.version >>


### PR DESCRIPTION
This avoids potentially seeing multiple "Install SecretHub CLI" steps in the GUI, even though it merely _checks_ whether SecretHub is installed, rather than repeatedly reinstalling it.