### PR TITLE
Fix chicken-egg issue for CircleCI integration tests workflow (alternative)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,31 +62,18 @@ workflows:
       - orb-tools/lint
       - orb-tools/pack
       - orb-tools/publish-dev:
-          name: publish-dev-sha
           orb-name: secrethub/cli
           context: publish-orb-dev
-          publish-alpha-version: false
+          publish-alpha-version: true
           publish-sha-version: true
           requires:
             - orb-tools/lint
             - orb-tools/pack
-      - orb-tools/publish-dev:
-          name: publish-dev-latest
-          orb-name: secrethub/cli
-          context: publish-orb-dev
-          publish-alpha-version: true
-          alpha-version-ref: dev:latest
-          publish-sha-version: false
-          requires:
-            - publish-dev-sha
-          filters:
-            branches:
-              only: master
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-tests
           context: publish-orb-dev
           requires:
-            - publish-dev-sha
+            - orb-tools/publish-dev
 
   test-integration:
     when: << pipeline.parameters.run-integration-tests >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,22 @@ workflows:
       - test-integration-exec
       - test-integration-other-orb
 
+  # Republish the dev:alpha orb every month to ensure new pipelines don't get rejected due to expired dev orbs.
+  keep-dev-orb:
+    triggers:
+      - schedule:
+          cron: "0 0 1 * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - orb-tools/publish-dev:
+          orb-name: secrethub/cli
+          context: publish-orb-dev
+          publish-alpha-version: true
+          publish-sha-version: false
+
   publish-to-registry:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,11 @@ parameters:
       The 'orb-tools/trigger-integration-tests-workflow' job kicks off the integration tests, by triggering a new workflow with this parameter set to 'true'.
   dev-orb-version:
     type: string
-    default: 1.0.1
+    default: "dev:alpha"
     description: >
-      The SecretHub dev orb version to use in the integration tests.
-      Default value has to be (any) stable prod version, because pipelines with dev orbs older than 90 days will get rejected.
-      The 'orb-tools/trigger-integration-tests-workflow' job will override this parameter with "dev:${CIRCLE_SHA1:0:7}",
-      so that the integration tests are always ran with the latest orb code, instead of the stable prod version.
+      The SecretHub dev orb version to use in the integration tests. Default is "dev:alpha" for the initial config validation to pass.
+      The 'orb-tools/trigger-integration-tests-workflow' job will override this parameter with "dev:${CIRCLE_SHA1:0:7}", so that the integration tests
+      are always ran with the correct orb code. The scheduled 'keep-dev-orb' workflow will make sure the dev:alpha orb doesn't expire.
 
 orb_promotion_filters: &orb_promotion_filters
   branches:


### PR DESCRIPTION
Turns out https://github.com/secrethub/secrethub-circleci-orb/pull/37 doesn't cut it, because newly added integrations tests get validated against the prod version, instead of the dev version. This can cause them to get rejected when they contain unpublished code.

So that means that the only option we have now is to keep using `dev:alpha` as the default `dev-orb-version` and make sure it gets published often enough to not expire. To do this, this PR adds a scheduled job that runs once a month to (re)publish the latest version on `master` as `dev:alpha`.